### PR TITLE
MS-1555: create initial Helm Chart

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+HELM_DOCS_VERSION="1.11.0"
+
+# install helm-docs
+curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
+tar -xf /tmp/helm-docs.tar.gz helm-docs
+
+# validate docs
+./helm-docs
+git diff --exit-code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+name: check that Chart-README's are up-to-date
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+
+jobs:
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Run helm-docs
+        run: .github/helm-docs.sh
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@main
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# helm-webredirect
+# anynines Helm Charts
+
+This repository includes Helm Charts managed by [anynines GmbH](https://www.anynines.com).
+
+This repository can be added using the following command:
+
+```
+helm repo add anynines https://anynines.github.io/helm-charts
+```
+
+## Helm-Charts currently available via this Repository
+* [The web redirect Helm chart](charts/webredirect)

--- a/charts/webredirect/.helmignore
+++ b/charts/webredirect/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/webredirect/Chart.yaml
+++ b/charts/webredirect/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: webredirect
+version: 0.1.0
+description: A Helm chart to create web redirects using an Ingress in Kubernetes
+home: https://anynines.github.io/helm-charts
+sources:
+  - https://github.com/anynines/helm-charts
+maintainers:
+  - name: Maximilian Mueller
+    email: mmueller@anynines.com
+    url: https://managed-services.anynines.com/

--- a/charts/webredirect/README.md
+++ b/charts/webredirect/README.md
@@ -1,0 +1,75 @@
+# Helm web redirect
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+
+A Helm chart to create web redirects using an Ingress in Kubernetes
+
+**Homepage:** <https://anynines.github.io/helm-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Maximilian Mueller | <mmueller@anynines.com> | <https://managed-services.anynines.com/> |
+
+## Source Code
+
+* <https://github.com/anynines/helm-charts>
+
+## Requirements
+* a Kubernetes cluster with a Nginx Ingress installed (i.e. [ingress-nginx](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx))
+* [Helm CLI](https://helm.sh/docs/intro/install/)
+
+## Installing the chart
+To install the chart:
+```shell
+$ helm repo add anynines https://anynines.github.io/helm-charts
+$ helm install my-redirect anynines/webredirect
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `""` | override full name |
+| ingress.annotations | object | `{}` | additional annotations for the Ingress Resource |
+| ingress.className | string | `"nginx"` | className for the Ingress Controller (only Nginx Controllers are supported) |
+| ingress.destination.host | string | `"example.com"` | Hostname of the destination |
+| ingress.destination.path | string | `"/"` | Path to redirect to at the destination |
+| ingress.destination.port | int | `443` | Port used on the destination |
+| ingress.destination.redirect_code | int | `301` | Redirect-Code for the type of redirect, see [redirection_messages](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) |
+| ingress.source.hosts | list | `[]` | URLs that should be redirected to the destination |
+| ingress.tls.enabled | bool | `false` | enable/disable TLS certificates (clusterissuer should be configured using annotations) |
+| nameOverride | string | `""` | override release name |
+
+## Examples
+### simple redirect
+```yaml
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  source:
+    hosts:
+      - change1.me
+      - change2.me
+  destination:
+    host: "www.anynines.com"
+  tls:
+    enabled: true
+```
+
+### Redirect to subpath
+```yaml
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  source:
+    hosts:
+      - change3.me
+      - change4.me
+  destination:
+    host: "www.anynines.com"
+    path: "/de"
+  tls:
+    enabled: true
+```

--- a/charts/webredirect/README.md.gotmpl
+++ b/charts/webredirect/README.md.gotmpl
@@ -1,0 +1,56 @@
+# Helm web redirect
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+## Requirements
+* a Kubernetes cluster with a Nginx Ingress installed (i.e. [ingress-nginx](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx))
+* [Helm CLI](https://helm.sh/docs/intro/install/)
+
+## Installing the chart
+To install the chart:
+```shell
+$ helm repo add anynines https://anynines.github.io/helm-charts
+$ helm install my-redirect anynines/webredirect
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Examples
+### simple redirect
+```yaml
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  source:
+    hosts:
+      - change1.me
+      - change2.me
+  destination:
+    host: "www.anynines.com"
+  tls:
+    enabled: true
+```
+
+### Redirect to subpath
+```yaml
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  source:
+    hosts:
+      - change3.me
+      - change4.me
+  destination:
+    host: "www.anynines.com"
+    path: "/de"
+  tls:
+    enabled: true
+```

--- a/charts/webredirect/templates/_helpers.tpl
+++ b/charts/webredirect/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webredirect.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webredirect.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webredirect.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "webredirect.labels" -}}
+helm.sh/chart: {{ include "webredirect.chart" . }}
+{{ include "webredirect.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "webredirect.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "webredirect.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/webredirect/templates/ingress.yaml
+++ b/charts/webredirect/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- $fullName := include "webredirect.fullname" . -}}
+{{- $svcPort := .Values.ingress.destination.port -}}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "webredirect.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.ingress.destination.host }}:{{ $svcPort }}{{ .Values.ingress.destination.path}}"
+    nginx.ingress.kubernetes.io/permanent-redirect-code: "{{ .Values.ingress.destination.redirect_code }}"
+    {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if eq .Values.ingress.tls.enabled true}}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.source.hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ $fullName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.source.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+    {{- end }}

--- a/charts/webredirect/templates/service.yaml
+++ b/charts/webredirect/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "webredirect.fullname" . }}
+  labels:
+    {{- include "webredirect.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "webredirect.selectorLabels" . | nindent 4 }}

--- a/charts/webredirect/values.yaml
+++ b/charts/webredirect/values.yaml
@@ -1,0 +1,27 @@
+# -- override release name
+nameOverride: ""
+# -- override full name
+fullnameOverride: ""
+
+ingress:
+  # -- className for the Ingress Controller (only Nginx Controllers are supported)
+  className: "nginx"
+  # -- additional annotations for the Ingress Resource
+  annotations: {}
+    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt
+  source:
+    # -- URLs that should be redirected to the destination
+    hosts: []
+  destination:
+    # -- Hostname of the destination
+    host: "example.com"
+    # -- Path to redirect to at the destination
+    path: "/"
+    # -- Port used on the destination
+    port: 443
+    # -- Redirect-Code for the type of redirect, see [redirection_messages](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages)
+    redirect_code: 301
+  tls:
+    # -- enable/disable TLS certificates (clusterissuer should be configured using annotations)
+    enabled: false


### PR DESCRIPTION
* The line in charts/webredirect/templates/ingress.yaml#l9 is a comment using a ternary operator that might be used to replace ll. 3-8. Imho this is too complicated, but I left it in case we decide to use the shorter version.
* The line in charts/webredirect/templates/ingress.yaml#l18 is very long and might be shortened by building the redirect-destination in the beginning of the file. That way we could also omit the Port if it's default 443.
* The files `charts/webredirect/.helmignore`, `charts/webredirect/Chart.yaml` and `charts/webredirect/templates/_helpers.tpl` have for the most part been created using `helm create webredirect` which creates a Helm-Chart based on a template.